### PR TITLE
ci: use Node.js 22 in Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           ref: master
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.18.0'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
       - name: Setup pnpm


### PR DESCRIPTION
Set Node.js to 22 in the workflow to fix actions/setup-node failure.