### PR TITLE
ci: publishワークフローの修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: master
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-          run_install: false
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec qiita publish --all
         env:


### PR DESCRIPTION
setup-nodeでキャッシュにpnpmを指定するよりも前にpnpmがセットアップされている必要があるようです